### PR TITLE
#5 fix url

### DIFF
--- a/Rebus.LightInject/Rebus.LightInject.csproj
+++ b/Rebus.LightInject/Rebus.LightInject.csproj
@@ -8,7 +8,7 @@
 		<Copyright>Copyright Rebus FM ApS 2012</Copyright>
 		<PackageTags>rebus events</PackageTags>
 		<PackageDescription>Provides a LightInject container adapter for Rebus</PackageDescription>
-		<RepositoryUrl>https://github.com/rebus-org/Rebus</RepositoryUrl>
+		<RepositoryUrl>https://github.com/rebus-org/Rebus.LightInject</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageIcon>little_rebusbus2_copy-500x500.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.

Closes #5 